### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "grunt-fe-wget",
-    "description": "get common package for front-end",
-    "version": "0.1.0",
-    "homepage": "https://github.com/fedeoo/grunt-fe-wget",
-    "author": {
-      "name": "fedeoo",
-      "email": "tragedymi@163.com",
-      "url": "fedeoo.github.io"
-    },
-    "repository": {
-      "type": "git",
-      "url": "git://github.com/fedeoo/grunt-fe-wget.git"
-    },
-    "bugs": {
-      "url": "https://github.com/fedeoo/grunt-fe-wget/issues"
-    },
-    "licenses": [
-      {
-        "type": "MIT",
-        "url": "https://github.com/fedeoo/grunt-fe-wget/blob/master/LICENSE-MIT"
-      }
-    ],
-    "engines": {
-      "node": ">= 0.8.0"
-    },
-    "scripts": {
-      "test": "grunt test"
-    },
-    "dependencies": {
-        "async": "~0.2.10",
-        "unzip": "~0.1.9",
-        "rimraf": "~2.2.6",
-        "wget": "0.0.1",
-        "tar": "~0.1.19"
-    },
-    "devDependencies": {
-      "grunt-contrib-jshint": "~0.6.0",
-      "grunt-contrib-clean": "~0.4.0",
-      "grunt-contrib-nodeunit": "~0.2.0",
-      "grunt": "~0.4.2"
-    },
-    "peerDependencies": {
-      "grunt": "~0.4.2"
-    },
+  "name": "grunt-fe-wget",
+  "description": "get common package for front-end",
+  "version": "0.1.0",
+  "homepage": "https://github.com/fedeoo/grunt-fe-wget",
+  "author": {
+    "name": "fedeoo",
+    "email": "tragedymi@163.com",
+    "url": "fedeoo.github.io"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/fedeoo/grunt-fe-wget.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fedeoo/grunt-fe-wget/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/fedeoo/grunt-fe-wget/blob/master/LICENSE-MIT"
+    }
+  ],
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "async": "~0.2.10",
+    "unzip": "~0.1.9",
+    "rimraf": "~2.2.6",
+    "wget": "0.0.1",
+    "tar": "~0.1.19"
+  },
+  "devDependencies": {
+    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-nodeunit": "~0.2.0",
+    "grunt": "~0.4.2"
+  },
+  "peerDependencies": {
+    "grunt": ">=0.4.0"
+  },
   "keywords": [
     "gruntplugin"
   ]


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
